### PR TITLE
use CSS syntax for default font specification

### DIFF
--- a/girara/config.c
+++ b/girara/config.c
@@ -5,6 +5,7 @@
 #include <glib/gi18n-lib.h>
 
 #include "config.h"
+#include "css-definitions.h"
 #include "commands.h"
 #include "datastructures.h"
 #include "internal.h"
@@ -184,7 +185,7 @@ girara_config_load_default(girara_session_t* session)
   session->global.autohide_inputbar = true;
 
   /* settings */
-  girara_setting_add(session, "font",                     "monospace normal 9", STRING,  FALSE, _("Font"), cb_font, NULL);
+  girara_setting_add(session, "font",                     DEFAULT_FONT,         STRING,  FALSE, _("Font"), cb_font, NULL);
   girara_setting_add(session, "default-fg",               "#DDDDDD",            STRING,  TRUE,  _("Default foreground color"), NULL, NULL);
   girara_setting_add(session, "default-bg",               "#000000",            STRING,  TRUE,  _("Default background color"), NULL, NULL);
   girara_setting_add(session, "inputbar-fg",              "#9FBC00",            STRING,  TRUE,  _("Inputbar foreground color"), NULL, NULL);

--- a/girara/css-definitions.h
+++ b/girara/css-definitions.h
@@ -3,7 +3,15 @@
 #ifndef GIRARA_CSS_DEFINITIONS_H
 #define GIRARA_CSS_DEFINITIONS_H
 
+#include <gtk/gtk.h>
+
 #include "macros.h"
+
+#if GTK_CHECK_VERSION(3,20,0)
+#define DEFAULT_FONT "normal 9pt monospace"
+#else
+#define DEFAULT_FONT "monospace normal 9"
+#endif
 
 extern const char* CSS_TEMPLATE_PRE_3_20 GIRARA_HIDDEN;
 extern const char* CSS_TEMPLATE_POST_3_20 GIRARA_HIDDEN;

--- a/girara/session.c
+++ b/girara/session.c
@@ -94,7 +94,7 @@ fill_template_with_values(girara_session_t* session)
     girara_template_set_variable_value(csstemplate, "font", font);
     g_free(font);
   } else {
-    girara_template_set_variable_value(csstemplate, "font", "monospace normal 9");
+    girara_template_set_variable_value(csstemplate, "font", DEFAULT_FONT);
   };
 
   /* parse color values */


### PR DESCRIPTION
GTK3 deprecated Pango-style font specifications ("family style size") in
favor of CSS-style specifications ("style size family", for example).
However, the compatibility layer for Pango specifications is broken and
causes a parsing failure in the CSS stylesheet which girara provides.

To both fix this and make girara compatible with future GTK versions
which drop the deprecated syntax, introduce a default which uses the new
syntax.