### PR TITLE
Check for glib version (to support glib-compile-resources) is run aft…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,9 @@ ${BUILDDIR}/${PROJECT}.pc: ${PROJECTNV}.pc.in config.mk
 
 ${OBJECTS}: config.mk \
 	${PROJECTNV}/version.h \
-	${PROJECTNV}/css-definitions.h \
 	.version-checks/GTK \
-	.version-checks/GLIB
+	.version-checks/GLIB \
+	${PROJECTNV}/css-definitions.h
 
 ${BUILDDIR_RELEASE}/%.o: %.c
 	$(call colorecho,CC,$<)
@@ -143,9 +143,9 @@ release: ${PROJECT}
 
 ${OBJECT_DEBUG}: config.mk \
 	${PROJECTNV}/version.h \
-	${PROJECTNV}/css-definitions.h \
 	.version-checks/GTK \
-	.version-checks/GLIB
+	.version-checks/GLIB \
+	${PROJECTNV}/css-definitions.h
 
 ${BUILDDIR_DEBUG}/%.o: %.c
 	$(call colorecho,CC,$<)


### PR DESCRIPTION
…er its first use

The problem (on a machine with glib<2.50) was:
```
$ make
 [GEN] girara/version.h 
 [GEN] girara/css-definitions.h 
Unknown option --dependency-file=.depend/girara/css-definitions.h.dep
Makefile:92: recipe for target 'girara/css-definitions.h' failed
make: *** [girara/css-definitions.h] Error 1
```
Where to build `css-definitions.h`, `glib-compile-resources` is used with the unknown option.

With this patch we get the intended error message:
```
$ make
The minimum required version of GLIB is 2.50
Makefile:64: recipe for target '.version-checks/GLIB' failed
make: *** [.version-checks/GLIB] Error 1
```
