### PR TITLE
fix pre-aborting input bar

### DIFF
--- a/girara/shortcuts.c
+++ b/girara/shortcuts.c
@@ -229,7 +229,7 @@ girara_isc_string_manipulation(girara_session_t* session, girara_argument_t* arg
       if (length != 1 && pos == 1 && (input[0] == ':' || input[0] == '/')) {
         break;
       }
-      if (length == 1 && pos == 1) {
+      if (length == 0 && pos == 0) {
         girara_isc_abort(session, argument, NULL, 0);
       }
       gtk_editable_delete_text(GTK_EDITABLE(session->gtk.inputbar_entry), pos - 1, pos);


### PR DESCRIPTION
## Issue
Input bar gets aborted before input string length and cursor position reaches zero.

## Changes Applied
Just modified the abort condition for `(input_length == 0 && cursor_pos == 0)` in [L232@shortcuts.c](https://github.com/abhinandanarya06/girara/blob/5d6cd77cee529a7ead6105a02285f8c214f602a6/girara/shortcuts.c#L232)

