### PR TITLE
Ensure Notification Label Ellipsization to Prevent Window Resizing

### DIFF
--- a/girara/session.c
+++ b/girara/session.c
@@ -380,6 +380,8 @@ girara_session_create(void)
 
   /* make notification text selectable */
   gtk_label_set_selectable(GTK_LABEL(session->gtk.notification_text), TRUE);
+  /* ellipsize notification text */
+  gtk_label_set_ellipsize(session->gtk.notification_text, PANGO_ELLIPSIZE_END);
 
   return session;
 }


### PR DESCRIPTION
## Overview
This pull request addresses an issue where the notification label (notification_text) within the notification_area dynamically resizes itself when a large amount of text is selected, causing unintended resizing of the entire window.

## Solution
To prevent the automatic resizing behavior, the following lines have been added to the girara_session_create function after line 382 in session.c:

```
/* ellipsize notification text */
gtk_label_set_ellipsize(session->gtk.notification_text, PANGO_ELLIPSIZE_END);
```
This sets the ellipsize property of the notification label to PANGO_ELLIPSIZE_END, ensuring that the text is truncated with an ellipsis at the end if it exceeds the available space.

## Impact
This change prevents the window from resizing when a large amount of text is selected, providing a more consistent and user-friendly experience.

## Testing
Testing has been performed by selecting varying amounts of text to ensure that the notification label behaves as expected and that the window size remains stable.