### PR TITLE
Enable emptying of command buffer with escape key

### DIFF
--- a/girara/callbacks.c
+++ b/girara/callbacks.c
@@ -152,6 +152,18 @@ girara_callback_view_key_press_event(GtkWidget* widget,
     if (session->events.buffer_changed != NULL) {
       session->events.buffer_changed(session);
     }
+  } else if (keyval == GDK_KEY_Escape) {
+    if (session_private->buffer.command != NULL) {
+      g_string_free(session_private->buffer.command, TRUE);
+      session_private->buffer.command = NULL;
+    }
+    if (session->global.buffer != NULL) {
+      g_string_free(session->global.buffer, TRUE);
+      session->global.buffer = NULL;
+    }
+    if (session->events.buffer_changed != NULL) {
+      session->events.buffer_changed(session);
+    }
   }
 
   /* check for buffer command */


### PR DESCRIPTION
From @kayprish (see #34):

This patch is meant to allow the user to cancel a command they've partially written in the session buffer. For example, if a user in zathura has mistakenly typed the `g' key instead of `G', they can cancel their partial command by pressing the Escape key.