### PR TITLE
add missing override_dependency for subproject in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -152,6 +152,7 @@ pkg.generate(
 )
 
 girara_dependency = declare_dependency(link_with: girara, include_directories: include_directories)
+meson.override_dependency('girara-gtk3', girara_dependency)
 
 subdir('doc')
 subdir('tests')


### PR DESCRIPTION
to be able to add this library more easily as a sub-project

with my commit:
```meson.build
subproject('girara')

executable('tmp',
  'main.c',
  dependencies : [dependency ('girara-gtk3')]
)
```

without my commit:
```meson.build
girara_project = subproject('girara')

executable('tmp',
  'main.c',
  dependencies : [girara_project.get_variable('girara_dependency')],
)
```