### PR TITLE
Replace GtkScrolledWindow with GtkStack

### DIFF
--- a/data/girara.css_t
+++ b/data/girara.css_t
@@ -8,15 +8,6 @@
   font-style: @font-style@;
 }
 
-/* Scrollbar */
-#@session@ scrolledwindow scrollbar {
-  background-color: @scrollbar-bg@;
-}
-
-#@session@ scrolledwindow scrollbar > slider {
-  background-color: @scrollbar-fg@;
-}
-
 /* Inputbar */
 #@session@ entry.inputbar {
   background-color: @inputbar-bg@;

--- a/girara/config.c
+++ b/girara/config.c
@@ -56,8 +56,6 @@ static void cb_guioptions(girara_session_t* session, const char* UNUSED(name), g
   /* set default values */
   bool show_commandline = false;
   bool show_statusbar   = false;
-  bool show_hscrollbar  = false;
-  bool show_vscrollbar  = false;
 
   /* evaluate input */
   const char* input         = value;
@@ -72,12 +70,6 @@ static void cb_guioptions(girara_session_t* session, const char* UNUSED(name), g
     /* statusbar */
     case 's':
       show_statusbar = true;
-      break;
-    case 'h':
-      show_hscrollbar = true;
-      break;
-    case 'v':
-      show_vscrollbar = true;
       break;
     }
   }
@@ -98,8 +90,6 @@ static void cb_guioptions(girara_session_t* session, const char* UNUSED(name), g
     session->global.hide_statusbar = true;
     gtk_widget_hide(session->gtk.statusbar);
   }
-
-  scrolled_window_set_scrollbar_visibility(GTK_SCROLLED_WINDOW(session->gtk.view), show_hscrollbar, show_vscrollbar);
 }
 
 void girara_config_load_default(girara_session_t* session) {
@@ -139,8 +129,6 @@ void girara_config_load_default(girara_session_t* session) {
   girara_setting_add(session, "notification-warning-bg",  "#F3F000",            STRING,  FALSE,  _("Warning notifaction background color"), cb_color, NULL);
   girara_setting_add(session, "notification-fg",          "#000000",            STRING,  FALSE,  _("Notification foreground color"), cb_color, NULL);
   girara_setting_add(session, "notification-bg",          "#FFFFFF",            STRING,  FALSE,  _("Notification background color"), cb_color, NULL);
-  girara_setting_add(session, "scrollbar-fg",             "#DDDDDD",            STRING,  FALSE,  _("Scrollbar foreground color"), cb_color, NULL);
-  girara_setting_add(session, "scrollbar-bg",             "#000000",            STRING,  FALSE,  _("Scrollbar background color"), cb_color, NULL);
   girara_setting_add(session, "word-separator",           " /.-=&#?",           STRING,  TRUE,  NULL, NULL, NULL);
   girara_setting_add(session, "window-width",             &window_width,        INT,     TRUE,  _("Initial window width"), NULL, NULL);
   girara_setting_add(session, "window-height",            &window_height,       INT,     TRUE,  _("Initial window height"), NULL, NULL);

--- a/girara/internal.h
+++ b/girara/internal.h
@@ -40,9 +40,6 @@ HIDDEN void widget_add_class(GtkWidget* widget, const char* styleclass);
 
 HIDDEN void widget_remove_class(GtkWidget* widget, const char* styleclass);
 
-HIDDEN void scrolled_window_set_scrollbar_visibility(GtkScrolledWindow* window, bool show_horizontal,
-                                                     bool show_vertical);
-
 /**
  * Default complection function for the settings
  *

--- a/girara/session.c
+++ b/girara/session.c
@@ -56,8 +56,6 @@ static void init_template_engine(GiraraTemplate* csstemplate) {
       "notification-warning-bg",
       "notification-fg",
       "notification-bg",
-      "scrollbar-fg",
-      "scrollbar-bg",
       "bottombox-padding1",
       "bottombox-padding2",
       "bottombox-padding3",
@@ -142,8 +140,6 @@ static void fill_template_with_values(girara_session_t* session) {
       "notification-warning-bg",
       "notification-fg",
       "notification-bg",
-      "scrollbar-fg",
-      "scrollbar-bg",
   };
 
   for (size_t i = 0; i < LENGTH(color_settings); ++i) {
@@ -209,20 +205,6 @@ static void css_template_changed(GiraraTemplate* csstemplate, girara_session_t* 
   if (gtk_css_provider_load_from_data(provider, css_data, -1, &error) == FALSE) {
     girara_error("Unable to load CSS: %s", error->message);
   }
-}
-
-void scrolled_window_set_scrollbar_visibility(GtkScrolledWindow* window, bool show_horizontal, bool show_vertical) {
-  GtkPolicyType hpolicy = GTK_POLICY_AUTOMATIC;
-  GtkPolicyType vpolicy = GTK_POLICY_AUTOMATIC;
-
-  if (show_horizontal == false) {
-    hpolicy = GTK_POLICY_EXTERNAL;
-  }
-  if (show_vertical == false) {
-    vpolicy = GTK_POLICY_EXTERNAL;
-  }
-
-  gtk_scrolled_window_set_policy(window, hpolicy, vpolicy);
 }
 
 static void mode_string_free(void* data) {
@@ -296,9 +278,8 @@ girara_session_t* girara_session_create(void) {
   session->gtk.statusbar_entries  = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   session->gtk.inputbar_box       = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   gtk_box_set_homogeneous(session->gtk.inputbar_box, TRUE);
-  session->gtk.view     = gtk_scrolled_window_new(NULL, NULL);
-  session->gtk.viewport = gtk_viewport_new(NULL, NULL);
-  gtk_widget_add_events(session->gtk.viewport, GDK_SCROLL_MASK);
+  session->gtk.view = gtk_stack_new();
+  gtk_widget_add_events(session->gtk.view, GDK_SCROLL_MASK);
   session->gtk.statusbar         = gtk_event_box_new();
   session->gtk.notification_area = gtk_event_box_new();
   session->gtk.notification_text = gtk_label_new(NULL);
@@ -332,7 +313,7 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
   session->private_data->session_name = g_strdup((sessionname == NULL) ? "girara" : sessionname);
 
   /* enable smooth scroll events */
-  gtk_widget_add_events(session->gtk.viewport, GDK_SMOOTH_SCROLL_MASK);
+  gtk_widget_add_events(session->gtk.view, GDK_SMOOTH_SCROLL_MASK);
 
   /* load CSS style */
   fill_template_with_values(session);
@@ -389,21 +370,6 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
 
   session->signals.view_scroll_event = g_signal_connect(G_OBJECT(session->gtk.view), "scroll-event",
                                                         G_CALLBACK(girara_callback_view_scroll_event), session);
-
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(session->gtk.view), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-
-  /* invisible scrollbars */
-  g_autofree char* guioptions = NULL;
-  girara_setting_get(session, "guioptions", &guioptions);
-
-  const bool show_hscrollbar = guioptions != NULL && strchr(guioptions, 'h') != NULL;
-  const bool show_vscrollbar = guioptions != NULL && strchr(guioptions, 'v') != NULL;
-
-  scrolled_window_set_scrollbar_visibility(GTK_SCROLLED_WINDOW(session->gtk.view), show_hscrollbar, show_vscrollbar);
-
-  /* viewport */
-  gtk_container_add(GTK_CONTAINER(session->gtk.view), session->gtk.viewport);
-  gtk_viewport_set_shadow_type(GTK_VIEWPORT(session->gtk.viewport), GTK_SHADOW_NONE);
 
   /* statusbar */
   gtk_container_add(GTK_CONTAINER(session->gtk.statusbar), GTK_WIDGET(session->gtk.statusbar_entries));
@@ -636,7 +602,10 @@ void girara_notify(girara_session_t* session, int level, const char* format, ...
   gtk_widget_show(GTK_WIDGET(session->gtk.notification_area));
   gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
 
-  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+  GtkWidget* view_child = gtk_stack_get_visible_child(GTK_STACK(session->gtk.view));
+  if (view_child != NULL) {
+    gtk_widget_grab_focus(GTK_WIDGET(view_child));
+  }
 }
 
 void girara_dialog(girara_session_t* session, const char* dialog, bool invisible,
@@ -673,16 +642,14 @@ void girara_dialog(girara_session_t* session, const char* dialog, bool invisible
 bool girara_set_view(girara_session_t* session, GtkWidget* widget) {
   g_return_val_if_fail(session != NULL, false);
 
-  GtkWidget* child = gtk_bin_get_child(GTK_BIN(session->gtk.viewport));
-
-  if (child != NULL) {
-    g_object_ref(child);
-    gtk_container_remove(GTK_CONTAINER(session->gtk.viewport), child);
+  GtkWidget* parent = gtk_widget_get_parent(widget);
+  if (parent != session->gtk.view) {
+    gtk_container_add(GTK_CONTAINER(session->gtk.view), widget);
   }
 
-  gtk_container_add(GTK_CONTAINER(session->gtk.viewport), widget);
-  gtk_widget_show_all(widget);
-  gtk_widget_grab_focus(session->gtk.view);
+  gtk_widget_set_visible(widget, true);
+  gtk_stack_set_visible_child(GTK_STACK(session->gtk.view), widget);
+  gtk_widget_grab_focus(widget);
 
   return true;
 }

--- a/girara/session.h
+++ b/girara/session.h
@@ -23,7 +23,6 @@ struct girara_session_s {
     GtkWidget* window;            /**< The main window of the application */
     GtkBox* box;                  /**< A box that contains all widgets */
     GtkWidget* view;              /**< The view area of the applications widgets */
-    GtkWidget* viewport;          /**< The viewport of view */
     GtkWidget* statusbar;         /**< The statusbar */
     GtkBox* statusbar_entries;    /**< Statusbar entry box */
     GtkWidget* notification_area; /**< The notification area */
@@ -106,7 +105,9 @@ bool girara_session_init(girara_session_t* session, const char* appname) GIRARA_
 bool girara_session_destroy(girara_session_t* session) GIRARA_VISIBLE;
 
 /**
- * Sets the view widget of girara
+ * Sets the view widget of girara.
+ * Widget to be displayed should be either unparented,
+ * or previously passed to girara_set_view.
  *
  * @param session The used girara session
  * @param widget The widget that should be displayed

--- a/girara/shortcuts.c
+++ b/girara/shortcuts.c
@@ -141,7 +141,10 @@ bool girara_isc_abort(girara_session_t* session, girara_argument_t* UNUSED(argum
   gtk_editable_delete_text(GTK_EDITABLE(session->gtk.inputbar_entry), 0, -1);
 
   /* grab view */
-  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+  GtkWidget* view_child = gtk_stack_get_visible_child(GTK_STACK(session->gtk.view));
+  if (view_child != NULL) {
+    gtk_widget_grab_focus(GTK_WIDGET(view_child));
+  }
 
   /* hide inputbar */
   gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));


### PR DESCRIPTION
I'm working on a new document widget for Zathura which implements GtkScrollable directly. This doesn't work currently with girara due to the main application widget being wrapped in a viewport and then scrolled window by girara.
Simply removing the viewport works with the current zathura version since GtkScrolledWindow adds a viewport automatically to any child which does not implement GtkScrollable, but I found this caused issues with the index due to how it is shown.

The result is I believe girara should switch to using GtkStack for the view, and girara_set_view simply changes which child is visible. Downstream projects are then free to add a ScrolledWindow with the scrollbar settings if they want the original functionality.

## Migration

This is a breaking change, for any users of this library (other than Zathura which I have updated), follow below to have the same behavior as the previous version. See the Zathura project for an example patch (https://github.com/pwmt/zathura/pull/841).

- Wrap the widget previously passed to `girara_set_view` in a GtkScrolledWindow.
- Add css entries to css_t for the scrollbar fg and bg
- Add girara settings for "scrollbar-bg" and "scrollbar-fg", with callbacks to update
- Add "scrollbar-fg" and "scrollbar-bg" to your css init.
