### PR TITLE
fix double free

### DIFF
--- a/girara/commands.c
+++ b/girara/commands.c
@@ -270,7 +270,7 @@ static bool girara_cmd_map_unmap(girara_session_t* session, girara_list_t* argum
   int shortcut_key                             = 0;
   int shortcut_mouse_button                    = 0;
   girara_mode_t shortcut_mode                  = session->modes.normal;
-  g_autofree char* shortcut_argument_data      = NULL;
+  char* shortcut_argument_data                 = NULL;
   int shortcut_argument_n                      = 0;
   g_autofree char* shortcut_buffer_command     = NULL;
   girara_event_type_t event_type               = GIRARA_EVENT_BUTTON_PRESS;


### PR DESCRIPTION
`shortcut_argument_data` is set to an element of `argument_list`. The elements of `argument_list` are free'd here https://github.com/pwmt/girara/blob/9d4e4778c72f8d74013d19a173c957e8da134fe9/girara/commands.c#L796 afterwards, so it shouldn't be autofree'd. Causes a double free when arguments are passed to map.