### PR TITLE
fix small leaks and a broken history dedup loop

### DIFF
--- a/girara/input-history.c
+++ b/girara/input-history.c
@@ -140,7 +140,7 @@ static void ih_append(GiraraInputHistory* history, const char* input) {
   }
 
   void* data = NULL;
-  while ((data = girara_list_find(list, list_strcmp, data)) != NULL) {
+  while ((data = girara_list_find(list, list_strcmp, input)) != NULL) {
     girara_list_remove(list, data);
   }
 

--- a/girara/utils.c
+++ b/girara/utils.c
@@ -65,12 +65,12 @@ bool girara_xdg_open_with_working_directory(const char* uri, const char* working
   bool res                = g_spawn_async(working_directory, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
   if (error != NULL) {
     girara_warning("Failed to execute 'xdg-open %s': %s", uri, error->message);
-    error = NULL;
+    g_clear_error(&error);
   }
 
   if (res == false) {
     /* fall back to `gio open` */
-    char* current_dir = working_directory != NULL ? g_get_current_dir() : NULL;
+    g_autofree char* current_dir = working_directory != NULL ? g_get_current_dir() : NULL;
     if (working_directory != NULL) {
       g_chdir(working_directory);
     }


### PR DESCRIPTION
- Overwriting the autoptr's tracked pointer leaks the GError struct that g_spawn_async allocates
- Make current_dir g_autofree to fix leak